### PR TITLE
WP: Created catalog-info.yaml file for SDP (backstage) integration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sml-python-method-template
+  description: This repository templates the development of a new python method for the Statistical Method Library
+  annotations:
+    jira/project-key: SPP
+    github.com/project-slug: ONSdigital/sml-python-method-template
+  tags:
+    - python
+    - spp
+    - sml
+    - template
+    - method
+  links:
+      title: SML Python Method Template
+      icon: search
+spec:
+  type: template
+  lifecycle: production
+  owner: group:spp-sml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -16,3 +16,4 @@ spec:
   type: template
   lifecycle: production
   owner: group:spp-sml
+  

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,9 +12,6 @@ metadata:
     - sml
     - template
     - method
-  links:
-      title: SML Python Method Template
-      icon: search
 spec:
   type: template
   lifecycle: production


### PR DESCRIPTION
### Synopsis
### SDP integration

Created a catalog-info.yaml for software developer portal integration. This will let the user to access the GitHub repository in the backstage instance.